### PR TITLE
Remove unused `*commands` arguments

### DIFF
--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -12,17 +12,11 @@ module TTY
       # @example Basic usage
       #   available # => 'less'
       #
-      # @example Usage with commands
-      #   available('less', 'cat')  # => 'less'
-      #
-      # @param [Array[String]] commands
-      #
       # @return [String]
       #
       # @api public
-      def self.available(*commands)
-        commands = commands.empty? ? executables : commands
-        commands.compact.uniq.find { |cmd| command_exists?(cmd) }
+      def self.available
+        executables.compact.uniq.find { |cmd| command_exists?(cmd) }
       end
 
       # Check if command is available
@@ -30,14 +24,11 @@ module TTY
       # @example Basic usage
       #   available?  # => true
       #
-      # @example Usage with command
-      #   available?('less') # => true
-      #
       # @return [Boolean]
       #
       # @api public
-      def self.available?(*commands)
-        !available(*commands).nil?
+      def self.available?
+        !available.nil?
       end
 
       # Use system command to page output text
@@ -113,11 +104,11 @@ module TTY
       #   the name of executable to run
       #
       # @api private
-      def pager_command(*commands)
-        @pager_command = if @pager_command && commands.empty?
+      def pager_command
+        @pager_command = if @pager_command
                            @pager_command
                          else
-                           self.class.available(*commands)
+                           self.class.available
                          end
       end
     end # SystemPager

--- a/spec/unit/system/available_spec.rb
+++ b/spec/unit/system/available_spec.rb
@@ -18,13 +18,8 @@ RSpec.describe TTY::Pager::SystemPager, '#available' do
     expect(pager.available).to be_nil
   end
 
-  it "takes precedence over other commands" do
-    allow(pager).to receive(:command_exists?).with('more') { true }
-    expect(pager.available('more')).to eql('more')
-  end
-
   it "allows to query for available command" do
-    allow(pager).to receive(:available).with('less') { true }
-    expect(pager.available?('less')).to eq(true)
+    allow(pager).to receive(:available) { ["less"] }
+    expect(pager.available?).to eq(true)
   end
 end


### PR DESCRIPTION
I noticed that some of the methods in `SystemPager` took `*commands` as arguments, even though these optional arguments were never used anywhere that I could find. This PR simply removes them.