### PR TITLE
Change SystemPager to support piped git pagers

### DIFF
--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -22,7 +22,7 @@ module TTY
       # @api public
       def self.available(*commands)
         commands = commands.empty? ? executables : commands
-        commands.compact.uniq.find { |cmd| command_exists?(cmd) }
+        commands.compact.uniq.find { |cmd| command_exists?(cmd.split.first) }
       end
 
       # Check if command is available
@@ -87,7 +87,7 @@ module TTY
       # @api private
       def self.executables
         [ENV['GIT_PAGER'], ENV['PAGER'],
-         `git config --get-all core.pager`.split.first,
+         `git config --get-all core.pager`,
          'less', 'more', 'cat', 'pager']
       end
       private_class_method :executables

--- a/spec/unit/system/available_spec.rb
+++ b/spec/unit/system/available_spec.rb
@@ -27,4 +27,16 @@ RSpec.describe TTY::Pager::SystemPager, '#available' do
     allow(pager).to receive(:available).with('less') { true }
     expect(pager.available?('less')).to eq(true)
   end
+
+  context "when given a multi-word executable" do
+    let(:execs) { ["diff-so-fancy | less --tabs=4 -RFX"] }
+
+    subject(:pager) { described_class }
+
+    it "finds the command" do
+      allow(pager).to receive(:executables).and_return(execs)
+      allow(pager).to receive(:command_exists?).with("diff-so-fancy") { true }
+      expect(pager.available).to eql(execs.first)
+    end
+  end
 end


### PR DESCRIPTION
This commit changes the way that default `git`
pagers are used by SystemPager so that piped
default pagers, or pagers with flags (for an
example of both see `diff-so-fancy`'s
recommendation here:
https://github.com/so-fancy/diff-so-fancy#usage)
both work as expected.

Closes #2.