### PR TITLE
Fix handling of blank commands

### DIFF
--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -24,7 +24,9 @@ module TTY
       # @api public
       def self.available(*commands)
         commands = commands.empty? ? executables : commands
-        commands.compact.uniq.find { |cmd| command_exists?(cmd.split.first) }
+        commands.
+          compact.map(&:strip).reject(&:empty?).uniq.
+          find { |cmd| command_exists?(cmd.split.first) }
       end
 
       # Check if command is available

--- a/spec/unit/system/available_spec.rb
+++ b/spec/unit/system/available_spec.rb
@@ -28,10 +28,17 @@ RSpec.describe TTY::Pager::SystemPager, '#available' do
     expect(pager.available?('less')).to eq(true)
   end
 
+  context "when given nil, blank, and whitespace commands" do
+    let(:execs) { [nil, "", "   ", "less"] }
+
+    it "does not error" do
+      allow(pager).to receive(:executables).and_return(execs)
+      expect(pager.available).to eql("less")
+    end
+  end
+
   context "when given a multi-word executable" do
     let(:execs) { ["diff-so-fancy | less --tabs=4 -RFX"] }
-
-    subject(:pager) { described_class }
 
     it "finds the command" do
       allow(pager).to receive(:executables).and_return(execs)


### PR DESCRIPTION
When a potential system pager passed in via
the environment variables or git configuration
yields a pager that is blank ("") or whitespace-
only ("  ") the call to `TTY::Which.exist?`
would raise an error.

This behavior could be fixed in either gem,
however I was wary of having `TTY::Which`
gracefully handle this case and then have
dependencies (including `TTY::Pager`) need
to know about its behavior when `nil` is
passed; as a result fixing `TTY::Pager`
seemed cleaner to me.

Closes #5.