### PR TITLE
Correct typo in `:command` option examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pager = TTY::Pager::BasicPager.new prompt: prompt
 You can force `SystemPager` to always use a specific paging tool by passing the `:command` option:
 
 ```ruby
-TTY::Pager.new command; 'less -R'
+TTY::Pager.new command: 'less -R'
 TTY::Pager::SystemPager.new command: 'less -R'
 ```
 


### PR DESCRIPTION
Heya @piotrmurach ,

Thanks for your work on the TTY project! Came across a small typo in the [:command](https://github.com/piotrmurach/tty-pager#command) example

Cheers! 🍺 