### PR TITLE
Fix: exception when using tty-pager with tty-file

### DIFF
--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -33,7 +33,7 @@ module TTY
       def self.run_command(*args)
         require 'tempfile'
         out = Tempfile.new('tty-pager')
-        result = system(*args, out: out.path, err: out.path, in: File::NULL)
+        result = system(*args, out: out.path, err: out.path, in: ::File::NULL)
         return if result.nil?
         out.rewind
         out.read


### PR DESCRIPTION
### Describe the change
Fix the exception when using tty-pager with tty-file

### Why are we doing this?
The exception:

gems/tty-pager-0.12.0/lib/tty/pager/system.rb:36:in `run_command': uninitialized constant TTY::File::NULL (NameError)

### Benefits
Fix bug.

### Drawbacks
N/A.

### Requirements
Put an X between brackets on each line if you have done the item:

[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
