### PR TITLE
Streaming support (spike)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ Then to perform actual content pagination invoke `page` method with the content 
 pager.page("Very long text...")
 ```
 
+If, instead of a single string, you'd like to paginate a long-running operation, you could use the `write` method instead and run `wait` to block until the user has closed the pager:
+
+```ruby
+File.open("file_with_lots_of_lines.txt", "r").each_line do |line|
+  # do some work with the line:
+  sleep 0.1
+
+  # try to send it to the pager:
+  success = pager.write(line)
+
+  if success
+    # keep going to the next line
+  else
+    # pager was closed, stop writing
+    break
+  end
+end
+
+# wait for the interface to be closed
+pager.wait
+```
+
 If you want to use specific pager you can do so by invoking it directly:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -56,29 +56,41 @@ Then to perform actual content pagination invoke `page` method with the content 
 pager.page("Very long text...")
 ```
 
-If, instead of a single string, you'd like to paginate a long-running operation, you could use the `write` method instead and run `wait` to block until the user has closed the pager:
+If, instead of a single string, you'd like to paginate a long-running operation, you could use the block form of the pager:
 
 ```ruby
-File.open("file_with_lots_of_lines.txt", "r").each_line do |line|
-  # do some work with the line:
-  sleep 0.1
+TTY::Pager.page do |pager|
+  File.open("file_with_lots_of_lines.txt", "r").each_line do |line|
+    # do some work with the line:
+    sleep 0.1
 
-  # try to send it to the pager:
-  success = pager.write(line)
-
-  if success
-    # keep going to the next line
-  else
-    # pager was closed, stop writing
-    break
+    # send it to the pager:
+    pager.write(line)
   end
 end
-
-# wait for the paging tool to be closed
-pager.wait
 ```
 
-If you want to use specific pager you can do so by invoking it directly:
+For more control, you could translate the block form into separate `write` and `close` calls:
+
+```ruby
+begin
+  pager = TTY::Pager.new
+
+  File.open("file_with_lots_of_lines.txt", "r").each_line do |line|
+    # do some work with the line:
+    sleep 0.1
+
+    # send it to the pager:
+    pager.write(line)
+  end
+rescue TTY::Pager::PagerClosed
+  # the user closed the paginating tool
+ensure
+  pager.close
+end
+```
+
+If you want to use a specific pager you can do so by invoking it directly:
 
 ```ruby
 pager = TTY::Pager::BasicPager.new

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ File.open("file_with_lots_of_lines.txt", "r").each_line do |line|
   end
 end
 
-# wait for the interface to be closed
+# wait for the paging tool to be closed
 pager.wait
 ```
 

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -92,6 +92,22 @@ module TTY
     def write(text, &callback)
       pager.write(text, &callback)
     end
+    alias_method :<<, :write
+
+    # Write a newline-ended line to the available pager
+    #
+    # @param [String] text
+    #   the text to send to the pager
+    #
+    # @yield [Integer] page number
+    #
+    # @return [Boolean]
+    #   whether the write succeeded, will be false if the pager was closed
+    #
+    # @api public
+    def puts(text, &callback)
+      pager.puts(text, &callback)
+    end
 
     # Wait for the pager to be closed
     #

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -78,6 +78,31 @@ module TTY
       self
     end
 
+    # Write the given text to the available pager
+    #
+    # @param [String] text
+    #   the text to send to the pager
+    #
+    # @yield [Integer] page number
+    #
+    # @return [Boolean]
+    #   whether the write succeeded, will be false if the pager was closed
+    #
+    # @api public
+    def write(text, &callback)
+      pager.write(text, &callback)
+    end
+
+    # Wait for the pager to be closed
+    #
+    # @return [Boolean]
+    #   whether the pager exited successfully
+    #
+    # @api public
+    def wait
+      pager.wait
+    end
+
     # The terminal height
     #
     # @api public

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -86,8 +86,8 @@ module TTY
     # @return [TTY::Pager]
     #
     # @api public
-    def page(text, &callback)
-      pager.page(text, &callback)
+    def page(text)
+      pager.page(text)
       self
     end
 
@@ -96,14 +96,15 @@ module TTY
     # @param [Array<String>] *args
     #   strings to send to the pager
     #
-    # @yield [Integer] page number
-    #
     # @raise [PagerClosed]
     #   if the write failed due to a closed pager tool
     #
+    # @return [TTY::Pager]
+    #
     # @api public
-    def write(*args, &callback)
-      pager.write(*args, &callback)
+    def write(*args)
+      pager.write(*args)
+      self
     end
     alias_method :<<, :write
 
@@ -112,14 +113,12 @@ module TTY
     # @param [String] text
     #   the text to send to the pager
     #
-    # @yield [Integer] page number
-    #
-    # @return [Boolean]
-    #   whether the write succeeded, will be false if the pager was closed
+    # @return [TTY::Pager]
     #
     # @api public
-    def puts(text, &callback)
-      pager.puts(text, &callback)
+    def puts(text)
+      pager.puts(text)
+      self
     end
 
     # Close the pager tool, wait for it to finish

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -52,8 +52,6 @@ module TTY
       if self.class == TTY::Pager
         @pager = self.class.select_pager(@enabled, commands).new(options)
       end
-
-      @running = false
     end
 
     # Check if pager is enabled
@@ -63,15 +61,6 @@ module TTY
     # @api public
     def enabled?
       !!@enabled
-    end
-
-    # Check if pager is currently running
-    #
-    # @return [Boolean]
-    #
-    # @api public
-    def running?
-      !!@running
     end
 
     # Page the given text through the available pager

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -52,6 +52,8 @@ module TTY
       if self.class == TTY::Pager
         @pager = self.class.select_pager(@enabled, commands).new(options)
       end
+
+      @running = false
     end
 
     # Check if pager is enabled
@@ -61,6 +63,15 @@ module TTY
     # @api public
     def enabled?
       !!@enabled
+    end
+
+    # Check if pager is currently running
+    #
+    # @return [Boolean]
+    #
+    # @api public
+    def running?
+      !!@running
     end
 
     # Page the given text through the available pager

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'forwardable'
 require 'tty-screen'
 
 require_relative 'pager/basic'
@@ -9,6 +10,8 @@ require_relative 'pager/version'
 
 module TTY
   class Pager
+    extend Forwardable
+
     Error = Class.new(StandardError)
     PagerClosed = Class.new(Error)
 
@@ -127,9 +130,7 @@ module TTY
     #   whether the pager exited successfully
     #
     # @api public
-    def close
-      pager.close
-    end
+    def_delegator :pager, :close
 
     # The terminal height
     #

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'forwardable'
 require 'tty-screen'
 
 require_relative 'pager/basic'
@@ -10,8 +9,6 @@ require_relative 'pager/version'
 
 module TTY
   class Pager
-    extend Forwardable
-
     Error = Class.new(StandardError)
     PagerClosed = Class.new(Error)
 
@@ -130,7 +127,9 @@ module TTY
     #   whether the pager exited successfully
     #
     # @api public
-    def_delegator :pager, :close
+    def close
+      pager.close
+    end
 
     # The terminal height
     #

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -106,7 +106,7 @@ module TTY
       pager.write(*args)
       self
     end
-    alias_method :<<, :write
+    alias << :write
 
     # Write a newline-ended line to the available pager
     #

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -51,7 +51,7 @@ module TTY
       commands = Array(options[:command])
 
       if self.class == TTY::Pager
-        @pager = self.class.select_pager(@enabled, commands).new(options)
+        @pager = self.class.select_pager(@enabled, commands).new(**options)
       end
     end
 

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -121,7 +121,7 @@ module TTY
         end
 
         def push(line)
-          if @lines_left.positive?
+          if @lines_left > 0
             @current_page << line
             @lines_left -= 1
           else

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -43,48 +43,94 @@ module TTY
       #
       # @api public
       def page(text, &callback)
-        page_num = 1
-        leftover = []
-        lines_left = @height
+        init
+        write(text, &callback)
+        wait
+      end
+
+      def init
+        @page_num = 1
+        @leftover = []
+        @lines_left = @height
+
+        @queue = Queue.new
+        @thread = Thread.new do
+          loop do
+            message = @queue.pop
+            if message.nil?
+              sleep 0.1
+              next
+            end
+
+            type    = message[0]
+            payload = message[1]
+
+            case type
+            when :quit then break
+            when :print then output.print(payload)
+            when :prompt then instance_exec(payload, &@prompt)
+            else
+              raise "Unknown message type: #{type}"
+            end
+          end
+        end
+      end
+
+      # TODO (2020-04-21) Encapsulate thread, queue, etc in a "State" struct
+      def write(text, &callback)
+        raise "Pager was not initialized" if @thread.nil? || @queue.nil? || @page_num.nil? || @leftover.nil? || @lines_left.nil?
 
         text.lines.each do |line|
           chunk = []
-          if !leftover.empty?
-            chunk = leftover
-            leftover = []
+          if !@leftover.empty?
+            chunk = @leftover
+            @leftover = []
           end
           wrapped_line = Strings.wrap(line, @width)
           wrapped_line.lines.each do |line_part|
-            if lines_left > 0
+            if @lines_left > 0
               chunk << line_part
-              lines_left -= 1
+              @lines_left -= 1
             else
-              leftover << line_part
+              @leftover << line_part
             end
           end
-          output.print(chunk.join)
+          @queue << [:print, chunk.join]
 
-          if lines_left == 0
-            break unless continue_paging?(page_num)
-            lines_left = @height
-            if leftover.size > 0
-              lines_left -= leftover.size
+          if @lines_left == 0
+            return false unless continue_paging?
+            @lines_left = @height
+            if @leftover.size > 0
+              @lines_left -= @leftover.size
             end
-            page_num += 1
-            return !callback.call(page_num) unless callback.nil?
+            @page_num += 1
+            return !callback.call(@page_num) unless callback.nil?
           end
         end
 
-        if leftover.size > 0
-          output.print(leftover.join)
+        if @leftover.size > 0
+          @queue << [:print, @leftover.join]
         end
+
+        true
+      end
+
+      def wait
+        @queue << [:quit, nil]
+        @thread.join
+
+        @queue = nil
+        @thread = nil
+        @page_num = nil
+        @leftover = nil
+        @lines_left = nil
       end
 
       private
 
       # @api private
-      def continue_paging?(page_num)
-        instance_exec(page_num, &@prompt)
+      def continue_paging?
+        @queue << [:prompt, @page_num]
         !@input.gets.chomp[/q/i]
       end
     end # BasicPager

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -66,7 +66,7 @@ module TTY
         end
         self
       end
-      alias_method :<<, :write
+      alias << write
 
       # Write text to the pager, prompting on page end. Returns false if the
       # pager was closed.

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -115,7 +115,7 @@ module TTY
       end
 
       def wait
-        return if !running?
+        return unless running?
         @state.queue << [:quit, nil]
         @state.thread.join
 

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -117,7 +117,10 @@ module TTY
           output.public_send(write_method, chunk.join)
 
           if @lines_left == 0
-            raise PagerClosed unless continue_paging?(@page_num)
+            unless continue_paging?(@page_num)
+              raise PagerClosed.new("The pager tool was closed")
+            end
+
             @lines_left = @height
             if @leftover.size > 0
               @lines_left -= @leftover.size

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -77,17 +77,17 @@ module TTY
       end
 
       def write(text, &callback)
-        start if !running?
+        start unless running?
 
         text.lines.each do |line|
           chunk = []
-          if !@state.leftover.empty?
+          unless @state.leftover.empty?
             chunk = @state.leftover
             @state.leftover = []
           end
           wrapped_line = Strings.wrap(line, @width)
           wrapped_line.lines.each do |line_part|
-            if @state.lines_left > 0
+            if @state.lines_left.positive?
               chunk << line_part
               @state.lines_left -= 1
             else
@@ -96,10 +96,10 @@ module TTY
           end
           @state.queue << [:print, chunk.join]
 
-          if @state.lines_left == 0
+          if @state.lines_left.zero?
             return false unless continue_paging?
             @state.lines_left = @height
-            if @state.leftover.size > 0
+            unless @state.leftover.empty?
               @state.lines_left -= @state.leftover.size
             end
             @state.page_num += 1
@@ -107,7 +107,7 @@ module TTY
           end
         end
 
-        if @state.leftover.size > 0
+        unless @state.leftover.empty?
           @state.queue << [:print, @state.leftover.join]
         end
 

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -44,8 +44,8 @@ module TTY
       # Page text
       #
       # @api public
-      def page(text, &callback)
-        write(text, &callback)
+      def page(text)
+        write(text)
       rescue PagerClosed
         # do nothing
       ensure
@@ -60,9 +60,9 @@ module TTY
       # @return [TTY::Pager::BasicPager]
       #
       # @api public
-      def write(*args, &callback)
+      def write(*args)
         args.each do |text|
-          send_text(:write, text, &callback)
+          send_text(:write, text)
         end
         self
       end
@@ -75,8 +75,8 @@ module TTY
       #   the success status of writing to the screen
       #
       # @api public
-      def try_write(*args, &callback)
-        write(text, &callback)
+      def try_write(*args)
+        write(text)
         true
       rescue PagerClosed
         false
@@ -88,8 +88,8 @@ module TTY
       #   if the pager was closed
       #
       # @api public
-      def puts(text, &callback)
-        send_text(:puts, text, &callback)
+      def puts(text)
+        send_text(:puts, text)
       end
 
       # The lower-level common implementation of printing methods
@@ -98,7 +98,7 @@ module TTY
       #   the success status of writing to the screen
       #
       # @api private
-      def send_text(write_method, text, &callback)
+      def send_text(write_method, text)
         text.lines.each do |line|
           chunk = []
           if !@leftover.empty?
@@ -123,7 +123,6 @@ module TTY
               @lines_left -= @leftover.size
             end
             @page_num += 1
-            callback.call(@page_num) unless callback.nil?
           end
         end
 

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -29,7 +29,7 @@ module TTY
         prompt_height = PAGE_BREAK.lines.to_a.size
         @height -= prompt_height
 
-        @state = nil
+        @printer = nil
       end
 
       # Default prompt for paging
@@ -38,7 +38,7 @@ module TTY
       #
       # @api private
       def default_prompt
-        proc { |page_num| output.puts Strings.wrap(PAGE_BREAK % page_num, @width) }
+        proc { |page_num| output.puts Strings.wrap(PAGE_BREAK % page_num, width) }
       end
 
       # Page text
@@ -52,84 +52,100 @@ module TTY
       def start
         # In case there's a previous pager running:
         wait
-
-        state = State.new(@height)
-        state.printer = Fiber.new do |command, message|
-          loop do
-            case command
-            when :quit then break
-            when :print then output.print(message)
-            when :prompt then instance_exec(message, &@prompt)
-            else
-              raise "Unknown command type: #{command}"
-            end
-
-            command, message = Fiber.yield
-          end
-        end
-
-        state
+        Printer.new(@width, @height, @output, @prompt)
       end
 
       def write(text, &callback)
-        @state ||= start
+        @printer ||= start
 
         text.lines.each do |line|
           chunk = []
-          unless @state.leftover.empty?
-            chunk = @state.leftover
-            @state.leftover = []
+          unless @printer.leftover.empty?
+            chunk = @printer.leftover
+            @printer.leftover = []
           end
           wrapped_line = Strings.wrap(line, @width)
           wrapped_line.lines.each do |line_part|
-            if @state.lines_left.positive?
+            if @printer.lines_left.positive?
               chunk << line_part
-              @state.lines_left -= 1
+              @printer.lines_left -= 1
             else
-              @state.leftover << line_part
+              @printer.leftover << line_part
             end
           end
-          @state.printer.resume(:print, chunk.join)
+          @printer.print(chunk.join)
 
-          if @state.lines_left.zero?
+          if @printer.lines_left.zero?
             return false unless continue_paging?
-            @state.lines_left = @height
-            unless @state.leftover.empty?
-              @state.lines_left -= @state.leftover.size
+            @printer.lines_left = @height
+            unless @printer.leftover.empty?
+              @printer.lines_left -= @printer.leftover.size
             end
-            @state.page_num += 1
-            return !callback.call(@state.page_num) unless callback.nil?
+            @printer.page_num += 1
+            return !callback.call(@printer.page_num) unless callback.nil?
           end
         end
 
-        unless @state.leftover.empty?
-          @state.printer.resume(:print, @state.leftover.join)
+        unless @printer.leftover.empty?
+          @printer.print(@printer.leftover.join)
         end
 
         true
       end
 
       def wait
-        return unless @state
-        @state.printer.resume(:quit, nil)
-        @state = nil
+        return unless @printer
+        @printer.quit
+        @printer = nil
       end
 
       private
 
       # @api private
       def continue_paging?
-        @state.printer.resume(:prompt, @state.page_num)
+        @printer.prompt(@printer.page_num)
         !@input.gets.chomp[/q/i]
       end
 
-      class State
-        attr_accessor :printer, :lines_left, :page_num, :leftover
+      class Printer
+        attr_accessor :lines_left, :page_num, :leftover
+        attr_reader :output, :width, :height
 
-        def initialize(height)
-          @page_num = 1
-          @leftover = []
+        def initialize(width, height, output, prompt)
+          @width  = width
+          @height = height
+          @output = output
+          @prompt = prompt
+
+          @page_num   = 1
+          @leftover   = []
           @lines_left = height
+
+          @fiber = Fiber.new do |command, message|
+            loop do
+              case command
+              when :quit then break
+              when :print then @output.print(message)
+              when :prompt then instance_exec(message, &@prompt)
+              else
+                raise "Unknown command type: #{command}"
+              end
+
+              command, message = Fiber.yield
+            end
+          end
+        end
+
+        def print(message)
+          @fiber.resume(:print, message)
+        end
+
+        def prompt(message)
+          @fiber.resume(:prompt, message)
+        end
+
+        def quit
+          @fiber.resume(:quit, nil)
         end
       end
     end # BasicPager

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -57,6 +57,28 @@ module TTY
       #
       # @api public
       def write(text, &callback)
+        send_text(:write, text, &callback)
+      end
+      alias_method :<<, :write
+
+      # Print a line of text to the pager, prompting on page end. Returns false
+      # if the pager was closed.
+      #
+      # @return [Boolean]
+      #   the success status of writing to the screen
+      #
+      # @api public
+      def puts(text, &callback)
+        send_text(:puts, text, &callback)
+      end
+
+      # The lower-level common implementation of printing methods
+      #
+      # @return [Boolean]
+      #   the success status of writing to the screen
+      #
+      # @api private
+      def send_text(write_method, text, &callback)
         text.lines.each do |line|
           chunk = []
           if !@leftover.empty?
@@ -72,7 +94,7 @@ module TTY
               @leftover << line_part
             end
           end
-          output.print(chunk.join)
+          output.public_send(write_method, chunk.join)
 
           if @lines_left == 0
             return false unless continue_paging?(@page_num)
@@ -86,7 +108,7 @@ module TTY
         end
 
         if @leftover.size > 0
-          output.print(@leftover.join)
+          output.public_send(write_method, @leftover.join)
         end
 
         true

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -49,6 +49,13 @@ module TTY
         reset
       end
 
+      # Write text to the pager, prompting on page end. Returns false if the
+      # pager was closed.
+      #
+      # @return [Boolean]
+      #   the success status of writing to the screen
+      #
+      # @api public
       def write(text, &callback)
         text.lines.each do |line|
           wrapped_line = Strings.wrap(line, @width)
@@ -73,15 +80,19 @@ module TTY
         true
       end
 
+      # Stop the pager, wait for it to clean up
+      #
+      # @api public
       def wait
         reset
+        true
       end
+
+      private
 
       def reset
         @pagination = Pagination.new(@height)
       end
-
-      private
 
       # @api private
       def stop_paging?

--- a/lib/tty/pager/null.rb
+++ b/lib/tty/pager/null.rb
@@ -6,14 +6,14 @@ module TTY
       # Pass output directly to stdout
       #
       # @api public
-      def page(text, &callback)
-        write(text, &callback)
+      def page(text)
+        write(text)
       end
 
       # Pass output directly to stdout
       #
       # @api public
-      def write(text, &_callback)
+      def write(text)
         return text unless output.tty?
 
         output.write(text)
@@ -23,7 +23,7 @@ module TTY
       # Pass output directly to stdout
       #
       # @api public
-      def puts(text, &_callback)
+      def puts(text)
         return text unless output.tty?
 
         output.puts(text)

--- a/lib/tty/pager/null.rb
+++ b/lib/tty/pager/null.rb
@@ -7,9 +7,23 @@ module TTY
       #
       # @api public
       def page(text, &callback)
+        write(text, &callback)
+      end
+
+      # Pass output directly to stdout
+      #
+      # @api public
+      def write(text, &_callback)
         return text unless output.tty?
 
-        output.puts(text)
+        output.write(text)
+      end
+
+      # Do nothing, always return success
+      #
+      # @api public
+      def wait
+        true
       end
     end
   end # Pager

--- a/lib/tty/pager/null.rb
+++ b/lib/tty/pager/null.rb
@@ -18,6 +18,16 @@ module TTY
 
         output.write(text)
       end
+      alias_method :<<, :write
+
+      # Pass output directly to stdout
+      #
+      # @api public
+      def puts(text, &_callback)
+        return text unless output.tty?
+
+        output.puts(text)
+      end
 
       # Do nothing, always return success
       #

--- a/lib/tty/pager/null.rb
+++ b/lib/tty/pager/null.rb
@@ -32,7 +32,7 @@ module TTY
       # Do nothing, always return success
       #
       # @api public
-      def wait
+      def close
         true
       end
     end

--- a/lib/tty/pager/null.rb
+++ b/lib/tty/pager/null.rb
@@ -18,7 +18,7 @@ module TTY
 
         output.write(text)
       end
-      alias_method :<<, :write
+      alias << write
 
       # Pass output directly to stdout
       #

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -159,6 +159,7 @@ module TTY
         @pager_io ||= spawn_pager
         @pager_io.write(text)
       end
+      alias_method :<<, :write
 
       # Stop the pager, wait for the process to finish. If no pager has been
       # started, returns true.

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -233,8 +233,9 @@ module TTY
       # @api private
       class PagerIO
         def initialize(command)
-          @io  = IO.popen(command, 'w')
-          @pid = @io.pid
+          @command = command
+          @io      = IO.popen(@command, 'w')
+          @pid     = @io.pid
         end
 
         def write(*args)
@@ -260,7 +261,7 @@ module TTY
         def io_call(method_name, *args)
           @io.public_send(method_name, *args)
         rescue Errno::EPIPE
-          raise PagerClosed
+          raise PagerClosed.new("The pager process (`#{@command}`) was closed")
         end
       end
     end # SystemPager

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -131,7 +131,7 @@ module TTY
         command = pager_command
         out = self.class.run_command(command)
         # Issue running command, e.g. unsupported flag, fallback to just command
-        if !out.empty?
+        unless out.empty?
           command = pager_command.split.first
         end
 
@@ -141,7 +141,7 @@ module TTY
       end
 
       def write(text)
-        start if !running?
+        start unless running?
         @pager_io.write(text)
         true
       rescue Errno::EPIPE
@@ -150,7 +150,7 @@ module TTY
       end
 
       def wait
-        return true if !running?
+        return true unless running?
         @pager_io.close
         _, status = Process.waitpid2(@pid, Process::WNOHANG)
         @pager_io = nil

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -128,6 +128,12 @@ module TTY
         wait
       end
 
+      # Spawn the pager process
+      #
+      # @return [PagerIO]
+      #   A wrapper for the external pager
+      #
+      # @api private
       def start
         # In case there's a previous pager running:
         wait
@@ -142,6 +148,13 @@ module TTY
         PagerIO.new(command)
       end
 
+      # Send text to the pager process. Starts a new process if it hasn't been
+      # started yet. Returns false if the pager was closed.
+      #
+      # @return [Boolean]
+      #   the success status of writing to the pager process
+      #
+      # @api public
       def write(text)
         @pager_io ||= start
         @pager_io.write(text)
@@ -151,6 +164,13 @@ module TTY
         false
       end
 
+      # Stop the pager, wait for the process to finish. If no pager has been
+      # started, returns true.
+      #
+      # @return [Boolean]
+      #   the exit status of the child process
+      #
+      # @api public
       def wait
         return true unless @pager_io
         status = @pager_io.close
@@ -175,6 +195,9 @@ module TTY
                          end
       end
 
+      # A wrapper for an external process.
+      #
+      # @api private
       class PagerIO
         def initialize(command)
           @io  = IO.popen(command, 'w')

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -135,7 +135,7 @@ module TTY
           command = pager_command.split.first
         end
 
-        @pager_io = open("|#{command}", 'w')
+        @pager_io = open("|#{command}", "w")
         @pid      = @pager_io.pid
         @running  = true
       end

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -166,7 +166,7 @@ module TTY
         @pager_io.write(*args)
         self
       end
-      alias_method :<<, :write
+      alias << write
 
       # Send text to the pager process. Starts a new process if it hasn't been
       # started yet.

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -123,7 +123,7 @@ module TTY
       #   the success status of launching a process
       #
       # @api public
-      def page(text, &_callback)
+      def page(text)
         write(text)
       rescue PagerClosed
         # do nothing

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -246,6 +246,7 @@ module TTY
         end
 
         def close
+          return true if @io.closed?
           @io.close
           _, status = Process.waitpid2(@pid, Process::WNOHANG)
           status.success?

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -135,7 +135,7 @@ module TTY
           command = pager_command.split.first
         end
 
-        @pager_io = open("|#{command}", "w")
+        @pager_io = IO.popen(command, 'w')
         @pid      = @pager_io.pid
         @running  = true
       end

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -144,7 +144,7 @@ module TTY
         start if !running?
         @pager_io.write(text)
         true
-      rescue Errno::EPIPE => e
+      rescue Errno::EPIPE
         # pager has likely been closed before output was done
         false
       end

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -186,7 +186,7 @@ module TTY
         end
 
         def close
-          status = @io.close
+          @io.close
           _, status = Process.waitpid2(@pid, Process::WNOHANG)
           status
         end

--- a/spec/unit/basic/page_spec.rb
+++ b/spec/unit/basic/page_spec.rb
@@ -138,4 +138,19 @@ RSpec.describe TTY::Pager::BasicPager, '.page' do
       "a"
     ].join("\n"))
   end
+
+  describe "block form" do
+    it "calls .close when the block is done" do
+      basic_pager = spy(:basic_pager)
+      allow(described_class).to receive(:new) { basic_pager }
+
+      text = "I try all things, I achieve what I can.\n"
+      described_class.page do |pager|
+        pager.write(text)
+      end
+
+      expect(basic_pager).to have_received(:write).with(text)
+      expect(basic_pager).to have_received(:close)
+    end
+  end
 end

--- a/spec/unit/null/page_spec.rb
+++ b/spec/unit/null/page_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe TTY::Pager::NullPager, '.page' do
     expect(pager.page(text)).to eq(text)
     expect(output.string).to eq('')
   end
+
+  it "doesn't write a newline if one wasn't given" do
+    allow(output).to receive(:tty?).and_return(true)
+    pager = described_class.new(output: output)
+    text = "I try all things, I achieve what I can."
+
+    pager.page(text)
+
+    expect(output.string).to eq(text)
+  end
 end

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -37,4 +37,20 @@ RSpec.describe TTY::Pager, '.page' do
 
     expect(system_pager).to have_received(:page).with(text)
   end
+
+  describe "block form" do
+    it "calls .close when the block is done" do
+      system_pager = spy(:system_pager)
+      allow(TTY::Pager::SystemPager).to receive(:exec_available?) { true }
+      allow(TTY::Pager::SystemPager).to receive(:new) { system_pager }
+
+      text = "I try all things, I achieve what I can.\n"
+      described_class.page do |pager|
+        pager.write(text)
+      end
+
+      expect(system_pager).to have_received(:write).with(text)
+      expect(system_pager).to have_received(:close)
+    end
+  end
 end

--- a/spec/unit/system/close_spec.rb
+++ b/spec/unit/system/close_spec.rb
@@ -1,30 +1,30 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::Pager::SystemPager, '.wait' do
+RSpec.describe TTY::Pager::SystemPager, '.close' do
   it "succeeds if a pager hasn't been spawned" do
     pager = described_class.new
 
     expect(pager).to receive(:spawn_pager).never
-    expect(pager.wait).to eq(true)
+    expect(pager.close).to eq(true)
   end
 
   it "succeeds if the pager exits successfully" do
     pager = described_class.new
-    pager_io = double("PagerIO", write: nil, close: nil, wait: true)
+    pager_io = double("PagerIO", write: nil, close: true)
     expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
 
     pager.write("test")
 
-    expect(pager.wait).to eq(true)
+    expect(pager.close).to eq(true)
   end
 
   it "fails if the pager exits with a failure" do
     pager = described_class.new
-    pager_io = double("PagerIO", write: nil, close: nil, wait: false)
+    pager_io = double("PagerIO", write: nil, close: false)
     expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
 
     pager.write("test")
 
-    expect(pager.wait).to eq(false)
+    expect(pager.close).to eq(false)
   end
 end

--- a/spec/unit/system/page_spec.rb
+++ b/spec/unit/system/page_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TTY::Pager::SystemPager, '.page' do
 
     allow(IO).to receive(:popen).and_return(write_io)
     allow(write_io).to receive(:pid).and_return(pid)
+    allow(write_io).to receive(:closed?).and_return(false)
     status = double(:status, :success? => true)
     allow(Process).to receive(:waitpid2).with(pid, any_args).and_return([1, status])
 

--- a/spec/unit/system/page_spec.rb
+++ b/spec/unit/system/page_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe TTY::Pager::SystemPager, '.page' do
     expect(write_io).to have_received(:write).with(text)
     expect(write_io).to have_received(:close)
   end
+
+  describe "block form" do
+    it "calls .close when the block is done" do
+      system_pager = spy(:system_pager)
+      allow(described_class).to receive(:exec_available?) { true }
+      allow(described_class).to receive(:new) { system_pager }
+
+      text = "I try all things, I achieve what I can.\n"
+      described_class.page do |pager|
+        pager.write(text)
+      end
+
+      expect(system_pager).to have_received(:write).with(text)
+      expect(system_pager).to have_received(:close)
+    end
+  end
 end

--- a/spec/unit/system/page_spec.rb
+++ b/spec/unit/system/page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TTY::Pager::SystemPager, '.page' do
     write_io = spy
     pid      = 12345
 
-    allow(pager).to receive(:open).and_return(write_io)
+    allow(IO).to receive(:popen).and_return(write_io)
     allow(write_io).to receive(:pid).and_return(pid)
     status = double(:status, :success? => true)
     allow(Process).to receive(:waitpid2).with(pid, any_args).and_return([1, status])

--- a/spec/unit/system/page_spec.rb
+++ b/spec/unit/system/page_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TTY::Pager::SystemPager, '.page' do
     status = double(:status, :success? => true)
     allow(Process).to receive(:waitpid2).with(pid, any_args).and_return([1, status])
 
-    expect(pager.page(text)).to eq(true)
+    pager.page(text)
     expect(write_io).to have_received(:write).with(text)
     expect(write_io).to have_received(:close)
   end

--- a/spec/unit/system/puts_spec.rb
+++ b/spec/unit/system/puts_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Pager::SystemPager, '.puts' do
+  it "triggers a start call exactly once" do
+    allow(TTY::Pager::SystemPager).to receive(:exec_available?).and_return(true)
+    output   = double(:output, :tty? => true)
+    pager    = described_class.new(output: output)
+    pager_io = double(:pager_io, puts: nil, close: nil, wait: true)
+
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
+
+    pager.puts("one")
+    pager.puts("two")
+    pager.wait
+  end
+
+  it "delegates any puts calls to the internal pager" do
+    pager = described_class.new
+    pager_io = StringIO.new
+
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
+
+    pager.puts("one")
+    pager.puts("two")
+
+    expect(pager_io.string).to eq("one\ntwo\n")
+  end
+
+  it "returns false if the pager process raises an exception" do
+    pager = described_class.new
+    pager_io = double("PagerIO")
+
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
+    expect(pager_io).to receive(:puts).and_return(false)
+
+    expect(pager.puts("one")).to eq(false)
+  end
+end

--- a/spec/unit/system/puts_spec.rb
+++ b/spec/unit/system/puts_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe TTY::Pager::SystemPager, '.puts' do
     allow(TTY::Pager::SystemPager).to receive(:exec_available?).and_return(true)
     output   = double(:output, :tty? => true)
     pager    = described_class.new(output: output)
-    pager_io = double(:pager_io, puts: nil, close: nil, wait: true)
+    pager_io = double(:pager_io, puts: nil, close: true)
 
     expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
 
     pager.puts("one")
     pager.puts("two")
-    pager.wait
+    pager.close
   end
 
   it "delegates any puts calls to the internal pager" do
@@ -22,17 +22,8 @@ RSpec.describe TTY::Pager::SystemPager, '.puts' do
 
     pager.puts("one")
     pager.puts("two")
+    pager.close
 
     expect(pager_io.string).to eq("one\ntwo\n")
-  end
-
-  it "returns false if the pager process raises an exception" do
-    pager = described_class.new
-    pager_io = double("PagerIO")
-
-    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
-    expect(pager_io).to receive(:puts).and_return(false)
-
-    expect(pager.puts("one")).to eq(false)
   end
 end

--- a/spec/unit/system/wait_spec.rb
+++ b/spec/unit/system/wait_spec.rb
@@ -4,27 +4,27 @@ RSpec.describe TTY::Pager::SystemPager, '.wait' do
   it "succeeds if a pager hasn't been spawned" do
     pager = described_class.new
 
-    expect(pager).to receive(:start).never
-    expect(pager.wait).to be_truthy
+    expect(pager).to receive(:spawn_pager).never
+    expect(pager.wait).to eq(true)
   end
 
   it "succeeds if the pager exits successfully" do
     pager = described_class.new
-    pager_io = double("PagerIO", write: nil, close: double(success?: true))
-    expect(pager).to receive(:start).once.and_return(pager_io)
+    pager_io = double("PagerIO", write: nil, close: nil, wait: true)
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
 
     pager.write("test")
 
-    expect(pager.wait).to be_truthy
+    expect(pager.wait).to eq(true)
   end
 
   it "fails if the pager exits with a failure" do
     pager = described_class.new
-    pager_io = double("PagerIO", write: nil, close: double(success?: false))
-    expect(pager).to receive(:start).once.and_return(pager_io)
+    pager_io = double("PagerIO", write: nil, close: nil, wait: false)
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
 
     pager.write("test")
 
-    expect(pager.wait).to be_falsey
+    expect(pager.wait).to eq(false)
   end
 end

--- a/spec/unit/system/wait_spec.rb
+++ b/spec/unit/system/wait_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Pager::SystemPager, '.wait' do
+  it "succeeds if a pager hasn't been spawned" do
+    pager = described_class.new
+
+    expect(pager).to receive(:start).never
+    expect(pager.wait).to be_truthy
+  end
+
+  it "succeeds if the pager exits successfully" do
+    pager = described_class.new
+    pager_io = double("PagerIO", write: nil, close: double(success?: true))
+    expect(pager).to receive(:start).once.and_return(pager_io)
+
+    pager.write("test")
+
+    expect(pager.wait).to be_truthy
+  end
+
+  it "fails if the pager exits with a failure" do
+    pager = described_class.new
+    pager_io = double("PagerIO", write: nil, close: double(success?: false))
+    expect(pager).to receive(:start).once.and_return(pager_io)
+
+    pager.write("test")
+
+    expect(pager.wait).to be_falsey
+  end
+end

--- a/spec/unit/system/write_spec.rb
+++ b/spec/unit/system/write_spec.rb
@@ -35,4 +35,14 @@ RSpec.describe TTY::Pager::SystemPager, '.write' do
 
     expect(pager.write("one")).to eq(false)
   end
+
+  it "is aliased to <<" do
+    pager = described_class.new
+    pager_io = double("PagerIO")
+
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
+    expect(pager_io).to receive(:write).and_return(false)
+
+    expect(pager << "one").to eq(false)
+  end
 end

--- a/spec/unit/system/write_spec.rb
+++ b/spec/unit/system/write_spec.rb
@@ -13,4 +13,26 @@ RSpec.describe TTY::Pager::SystemPager, '.write' do
     pager.write("two")
     pager.wait
   end
+
+  it "delegates any write calls to the internal pager" do
+    pager = described_class.new
+    pager_io = StringIO.new
+
+    expect(pager).to receive(:start).once.and_return(pager_io)
+
+    pager.write("one")
+    pager.write("two")
+
+    expect(pager_io.string).to eq("onetwo")
+  end
+
+  it "returns false if the pager process raises an exception" do
+    pager = described_class.new
+    pager_io = double("PagerIO")
+
+    expect(pager).to receive(:start).once.and_return(pager_io)
+    expect(pager_io).to receive(:write).and_raise(Errno::EPIPE)
+
+    expect(pager.write("one")).to be_falsey
+  end
 end

--- a/spec/unit/system/write_spec.rb
+++ b/spec/unit/system/write_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe TTY::Pager::SystemPager, '.write' do
-  it "triggers a start call exactly once" do
+  it "triggers a `spawn_pager` call exactly once" do
     allow(TTY::Pager::SystemPager).to receive(:exec_available?).and_return(true)
     output   = double(:output, :tty? => true)
     pager    = described_class.new(output: output)
-    pager_io = double(:pager_io, write: nil, close: nil, wait: true)
+    pager_io = double(:pager_io, write: nil, close: true)
 
     expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
 
     pager.write("one")
     pager.write("two")
-    pager.wait
+    pager.close
   end
 
   it "delegates any write calls to the internal pager" do
@@ -26,23 +26,13 @@ RSpec.describe TTY::Pager::SystemPager, '.write' do
     expect(pager_io.string).to eq("onetwo")
   end
 
-  it "returns false if the pager process raises an exception" do
-    pager = described_class.new
-    pager_io = double("PagerIO")
-
-    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
-    expect(pager_io).to receive(:write).and_return(false)
-
-    expect(pager.write("one")).to eq(false)
-  end
-
   it "is aliased to <<" do
     pager = described_class.new
     pager_io = double("PagerIO")
 
     expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
-    expect(pager_io).to receive(:write).and_return(false)
+    expect(pager_io).to receive(:write)
 
-    expect(pager << "one").to eq(false)
+    pager << "one"
   end
 end

--- a/spec/unit/system/write_spec.rb
+++ b/spec/unit/system/write_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Pager::SystemPager, '.write' do
+  it "triggers a start call exactly once" do
+    allow(TTY::Pager::SystemPager).to receive(:exec_available?).and_return(true)
+    output   = double(:output, :tty? => true)
+    pager    = described_class.new(output: output)
+    pager_io = double(:pager_io, write: nil, close: double(:success? => true))
+
+    expect(pager).to receive(:start).once.and_return(pager_io)
+
+    pager.write("one")
+    pager.write("two")
+    pager.wait
+  end
+end

--- a/spec/unit/system/write_spec.rb
+++ b/spec/unit/system/write_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe TTY::Pager::SystemPager, '.write' do
     allow(TTY::Pager::SystemPager).to receive(:exec_available?).and_return(true)
     output   = double(:output, :tty? => true)
     pager    = described_class.new(output: output)
-    pager_io = double(:pager_io, write: nil, close: double(:success? => true))
+    pager_io = double(:pager_io, write: nil, close: nil, wait: true)
 
-    expect(pager).to receive(:start).once.and_return(pager_io)
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
 
     pager.write("one")
     pager.write("two")
@@ -18,7 +18,7 @@ RSpec.describe TTY::Pager::SystemPager, '.write' do
     pager = described_class.new
     pager_io = StringIO.new
 
-    expect(pager).to receive(:start).once.and_return(pager_io)
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
 
     pager.write("one")
     pager.write("two")
@@ -30,9 +30,9 @@ RSpec.describe TTY::Pager::SystemPager, '.write' do
     pager = described_class.new
     pager_io = double("PagerIO")
 
-    expect(pager).to receive(:start).once.and_return(pager_io)
-    expect(pager_io).to receive(:write).and_raise(Errno::EPIPE)
+    expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
+    expect(pager_io).to receive(:write).and_return(false)
 
-    expect(pager.write("one")).to be_falsey
+    expect(pager.write("one")).to eq(false)
   end
 end

--- a/spec/unit/system/write_spec.rb
+++ b/spec/unit/system/write_spec.rb
@@ -28,11 +28,12 @@ RSpec.describe TTY::Pager::SystemPager, '.write' do
 
   it "is aliased to <<" do
     pager = described_class.new
-    pager_io = double("PagerIO")
+    pager_io = spy("PagerIO")
 
     expect(pager).to receive(:spawn_pager).once.and_return(pager_io)
-    expect(pager_io).to receive(:write)
 
     pager << "one"
+
+    expect(pager_io).to have_received(:write)
   end
 end


### PR DESCRIPTION
### Describe the change

The idea is to make it possible for a pager to continuously get output and render it. With this change, the system pager is able to do this. Here's an example that works for me (run in the root of the project):

``` ruby
$: << File.expand_path('./lib')
require 'tty-pager'

pager = TTY::Pager.new
file = File.join(File.dirname(__FILE__), 'examples/temp.txt')

File.open(file).each_line do |line|
  sleep 0.1
  if !pager.write(line)
    STDERR.puts "Pager was closed"
    break
  end
end

pager.wait
```

There are many more things to do and questions to consider:

### Why are we doing this? Benefits & Drawbacks

See discussion in https://github.com/piotrmurach/tty-pager/issues/13

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[] Code style checked? -- HoundCI seems over-eager, so not sure about code style. Happy to change.
[x] Rebased with `master` branch?
[x] Documentaion updated?
