### PR TITLE
Change to extract abstract pager and convert Pager to a module #16

### DIFF
--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -48,10 +48,14 @@ module TTY
       # if no system command is found, a BasicPager is used which
       # is a pure Ruby implementation known to work on any platform.
       #
+      # @param [Boolean] enabled
+      #   whether or not to allow paging
+      # @param [String] command
+      #   the command to run if available
+      #
       # @api private
-      def select_pager(**options)
-        enabled = options.fetch(:enabled) { true }
-        commands = Array(options[:command])
+      def select_pager(enabled: true, command: nil)
+        commands = Array(command)
 
         if !enabled
           NullPager

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -1,156 +1,79 @@
 # frozen_string_literal: true
 
-require 'tty-screen'
-
-require_relative 'pager/basic'
-require_relative 'pager/null'
-require_relative 'pager/system'
-require_relative 'pager/version'
+require_relative "pager/basic"
+require_relative "pager/null"
+require_relative "pager/system"
+require_relative "pager/version"
 
 module TTY
-  class Pager
+  module Pager
     Error = Class.new(StandardError)
     PagerClosed = Class.new(Error)
 
-    # Select an appriopriate pager
-    #
-    # If the user disabled paging then a NullPager is returned,
-    # otherwise a check is performed to find native system
-    # command to perform pagination with SystemPager. Finally,
-    # if no system command is found, a BasicPager is used which
-    # is a pure Ruby implementation known to work on any platform.
-    #
-    # @api private
-    def self.select_pager(enabled, commands)
-      if !enabled
-        NullPager
-      elsif SystemPager.exec_available?(*commands)
-        SystemPager
-      else
-        BasicPager
+    module ClassMethods
+      # Create a pager
+      #
+      # @param [Hash] options
+      # @option options [Proc] :prompt
+      #   a proc object that accepts page number
+      # @option options [IO] :input
+      #   the object to send input to
+      # @option options [IO] :output
+      #   the object to send output to
+      # @option options [Boolean] :enabled
+      #   disable/enable text paging
+      #
+      # @api public
+      def new(**options)
+        pager_klass = select_pager(**options)
+        @pager = pager_klass.new(**options)
+      end
+
+      # Paginate content through null, basic or system pager.
+      #
+      # @example
+      #   TTY::Pager.page do |pager|
+      #     pager.write "some text"
+      #   end
+      #
+      # @api public
+      def page(**options, &block)
+        @pager = new(**options)
+
+        begin
+          block.call(@pager)
+        rescue PagerClosed
+          # do nothing
+        ensure
+          @pager.close
+        end
+      end
+
+      # Select an appriopriate pager
+      #
+      # If the user disabled paging then a NullPager is returned,
+      # otherwise a check is performed to find native system
+      # command to perform pagination with SystemPager. Finally,
+      # if no system command is found, a BasicPager is used which
+      # is a pure Ruby implementation known to work on any platform.
+      #
+      # @api private
+      def select_pager(**options)
+        enabled = options.fetch(:enabled) { true }
+        commands = Array(options[:command])
+
+        if !enabled
+          NullPager
+        elsif SystemPager.exec_available?(*commands)
+          SystemPager
+        else
+          BasicPager
+        end
       end
     end
 
-    # Create a pager
-    #
-    # @param [Hash] options
-    # @option options [Proc] :prompt
-    #   a proc object that accepts page number
-    # @option options [IO] :input
-    #   the object to send input to
-    # @option options [IO] :output
-    #   the object to send output to
-    # @option options [Boolean] :enabled
-    #   disable/enable text paging
-    #
-    # @api public
-    def initialize(**options)
-      @input   = options.fetch(:input)  { $stdin }
-      @output  = options.fetch(:output) { $stdout }
-      @enabled = options.fetch(:enabled) { true }
-      commands = Array(options[:command])
+    extend ClassMethods
 
-      if self.class == TTY::Pager
-        @pager = self.class.select_pager(@enabled, commands).new(**options)
-      end
-    end
-
-    def self.page(**options, &block)
-      instance = new(**options)
-
-      begin
-        block.call(instance)
-      rescue PagerClosed
-        # do nothing
-      ensure
-        instance.close
-      end
-    end
-
-    # Check if pager is enabled
-    #
-    # @return [Boolean]
-    #
-    # @api public
-    def enabled?
-      !!@enabled
-    end
-
-    # Page the given text through the available pager
-    #
-    # @param [String] text
-    #   the text to run through a pager
-    #
-    # @yield [Integer] page number
-    #
-    # @return [TTY::Pager]
-    #
-    # @api public
-    def page(text)
-      pager.page(text)
-      self
-    end
-
-    # Write the given text to the available pager
-    #
-    # @param [Array<String>] *args
-    #   strings to send to the pager
-    #
-    # @raise [PagerClosed]
-    #   if the write failed due to a closed pager tool
-    #
-    # @return [TTY::Pager]
-    #
-    # @api public
-    def write(*args)
-      pager.write(*args)
-      self
-    end
-    alias << :write
-
-    # Write a newline-ended line to the available pager
-    #
-    # @param [String] text
-    #   the text to send to the pager
-    #
-    # @return [TTY::Pager]
-    #
-    # @api public
-    def puts(text)
-      pager.puts(text)
-      self
-    end
-
-    # Close the pager tool, wait for it to finish
-    #
-    # @return [Boolean]
-    #   whether the pager exited successfully
-    #
-    # @api public
-    def close
-      pager.close
-    end
-
-    # The terminal height
-    #
-    # @api public
-    def page_height
-      TTY::Screen.height
-    end
-
-    # The terminal width
-    #
-    # @api public
-    def page_width
-      TTY::Screen.width
-    end
-
-    protected
-
-    attr_reader :output
-
-    attr_reader :input
-
-    attr_reader :pager
+    private_class_method :select_pager
   end # Pager
 end # TTY

--- a/lib/tty/pager.rb
+++ b/lib/tty/pager.rb
@@ -25,8 +25,7 @@ module TTY
       #
       # @api public
       def new(**options)
-        pager_klass = select_pager(**options)
-        @pager = pager_klass.new(**options)
+        select_pager(**options).new(**options)
       end
 
       # Paginate content through null, basic or system pager.
@@ -38,15 +37,7 @@ module TTY
       #
       # @api public
       def page(**options, &block)
-        @pager = new(**options)
-
-        begin
-          block.call(@pager)
-        rescue PagerClosed
-          # do nothing
-        ensure
-          @pager.close
-        end
+        select_pager(**options).page(**options, &block)
       end
 
       # Select an appriopriate pager

--- a/lib/tty/pager/abstract.rb
+++ b/lib/tty/pager/abstract.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module TTY
+  module Pager
+    class Abstract
+      UndefinedMethodError = Class.new(StandardError)
+
+      # Paginate content through null, basic or system pager.
+      #
+      # @api public
+      def self.page(**options, &block)
+        instance = new(**options)
+
+        begin
+          block.call(instance)
+        rescue PagerClosed
+          # do nothing
+        ensure
+          instance.close
+        end
+      end
+
+      # Create a pager
+      #
+      # @param [Hash] options
+      # @option options [Proc] :prompt
+      #   a proc object that accepts page number
+      # @option options [IO] :input
+      #   the object to send input to
+      # @option options [IO] :output
+      #   the object to send output to
+      # @option options [Boolean] :enabled
+      #   disable/enable text paging
+      #
+      # @api public
+      def initialize(**options)
+        @input   = options.fetch(:input)  { $stdin }
+        @output  = options.fetch(:output) { $stdout }
+        @enabled = options.fetch(:enabled) { true }
+      end
+
+      # Check if pager is enabled
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def enabled?
+        !!@enabled
+      end
+
+      # Page text
+      #
+      # @example
+      #   page('some long text...')
+      #
+      # @param [String] text
+      #   the text to paginate
+      #
+      # @api public
+      def page(text)
+        write(text)
+      rescue PagerClosed
+        # do nothing
+      ensure
+        close
+      end
+
+      # Try writing to the pager. Return false if the pager was closed.
+      #
+      # In case of system pager, send text to
+      # the pager process. Start a new process if it hasn't been
+      # started yet.
+      #
+      # @param [Array<String>] *args
+      #   strings to send to the pager
+      #
+      # @return [Boolean]
+      #   the success status of writing to the pager process
+      #
+      # @api public
+      def try_write(*args)
+        write(*args)
+        true
+      rescue PagerClosed
+        false
+      end
+
+      def write(*args)
+        raise UndefinedMethodError
+      end
+
+      def puts(*args)
+        raise UndefinedMethodError
+      end
+
+      def close(*args)
+        raise UndefinedMethodError
+      end
+
+      protected
+
+      attr_reader :output
+
+      attr_reader :input
+
+    end # Abstract
+  end # Pager
+end # TTY

--- a/lib/tty/pager/abstract.rb
+++ b/lib/tty/pager/abstract.rb
@@ -22,21 +22,18 @@ module TTY
 
       # Create a pager
       #
-      # @param [Hash] options
-      # @option options [Proc] :prompt
-      #   a proc object that accepts page number
-      # @option options [IO] :input
+      # @param [IO] :input
       #   the object to send input to
-      # @option options [IO] :output
+      # @param [IO] :output
       #   the object to send output to
-      # @option options [Boolean] :enabled
+      # @param [Boolean] :enabled
       #   disable/enable text paging
       #
       # @api public
-      def initialize(**options)
-        @input   = options.fetch(:input)  { $stdin }
-        @output  = options.fetch(:output) { $stdout }
-        @enabled = options.fetch(:enabled) { true }
+      def initialize(input: $stdin, output: $stdout, enabled: true)
+        @input   = input
+        @output  = output
+        @enabled = enabled
       end
 
       # Check if pager is enabled

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
-require 'strings'
+require "strings"
+require "tty-screen"
+
+require_relative "abstract"
 
 module TTY
-  class Pager
+  module Pager
     # A basic pager is used to work on systems where
     # system pager is not supported.
     #
     # @api public
-    class BasicPager < Pager
+    class BasicPager < Abstract
       PAGE_BREAK = "\n--- Page -%s- " \
                     "Press enter/return to continue " \
                     "(or q to quit) ---"
@@ -23,8 +26,8 @@ module TTY
       # @api public
       def initialize(**options)
         super
-        @height  = options.fetch(:height) { page_height }
-        @width   = options.fetch(:width)  { page_width }
+        @height  = options.fetch(:height) { TTY::Screen.height }
+        @width   = options.fetch(:width)  { TTY::Screen.width }
         @prompt  = options.fetch(:prompt) { default_prompt }
         prompt_height = PAGE_BREAK.lines.to_a.size
         @height -= prompt_height
@@ -39,17 +42,6 @@ module TTY
       # @api private
       def default_prompt
         proc { |page_num| output.puts Strings.wrap(PAGE_BREAK % page_num, @width) }
-      end
-
-      # Page text
-      #
-      # @api public
-      def page(text)
-        write(text)
-      rescue PagerClosed
-        # do nothing
-      ensure
-        reset
       end
 
       # Write text to the pager, prompting on page end.
@@ -68,20 +60,6 @@ module TTY
       end
       alias << write
 
-      # Write text to the pager, prompting on page end. Returns false if the
-      # pager was closed.
-      #
-      # @return [Boolean]
-      #   the success status of writing to the screen
-      #
-      # @api public
-      def try_write(*args)
-        write(text)
-        true
-      rescue PagerClosed
-        false
-      end
-
       # Print a line of text to the pager, prompting on page end.
       #
       # @raise [PagerClosed]
@@ -90,6 +68,25 @@ module TTY
       # @api public
       def puts(text)
         send_text(:puts, text)
+      end
+
+      # Stop the pager, wait for it to clean up
+      #
+      # @api public
+      def close
+        reset
+        true
+      end
+
+      private
+
+      # Reset internal state
+      #
+      # @api private
+      def reset
+        @page_num = 1
+        @leftover = []
+        @lines_left = @height
       end
 
       # The lower-level common implementation of printing methods
@@ -132,22 +129,6 @@ module TTY
         if @leftover.size > 0
           output.public_send(write_method, @leftover.join)
         end
-      end
-
-      # Stop the pager, wait for it to clean up
-      #
-      # @api public
-      def close
-        reset
-        true
-      end
-
-      private
-
-      def reset
-        @page_num = 1
-        @leftover = []
-        @lines_left = @height
       end
 
       # @api private

--- a/lib/tty/pager/basic.rb
+++ b/lib/tty/pager/basic.rb
@@ -18,17 +18,20 @@ module TTY
 
       # Create a basic pager
       #
-      # @option options [Integer] :height
+      # @param [Integer] :height
       #   the terminal height
-      # @option options [Integer] :width
+      # @param [Integer] :width
       #   the terminal width
+      # @param [Proc] :prompt
+      #   a proc object that accepts page number
       #
       # @api public
-      def initialize(**options)
-        super
-        @height  = options.fetch(:height) { TTY::Screen.height }
-        @width   = options.fetch(:width)  { TTY::Screen.width }
-        @prompt  = options.fetch(:prompt) { default_prompt }
+      def initialize(height: TTY::Screen.height, width: TTY::Screen.width,
+                     prompt: default_prompt, **options)
+        super(**options)
+        @height  = height
+        @width   = width
+        @prompt  = prompt
         prompt_height = PAGE_BREAK.lines.to_a.size
         @height -= prompt_height
 

--- a/lib/tty/pager/null.rb
+++ b/lib/tty/pager/null.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 
-module TTY
-  class Pager
-    class NullPager < Pager
-      # Pass output directly to stdout
-      #
-      # @api public
-      def page(text)
-        write(text)
-      end
+require_relative "abstract"
 
+module TTY
+  module Pager
+    class NullPager < Abstract
       # Pass output directly to stdout
       #
       # @api public

--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -93,17 +93,15 @@ module TTY
 
       # Create a system pager
       #
-      # @param [Hash] options
-      # @option options [String] :command
+      # @param [String] :command
       #   the command to use for paging
       #
       # @api public
-      def initialize(**options)
-        super
+      def initialize(command: nil, **options)
+        super(**options)
         @pager_io = nil
         @pager_command = nil
-        commands = Array(options[:command])
-        pager_command(*commands)
+        pager_command(*Array(command))
 
         if @pager_command.nil?
           raise TTY::Pager::Error, "#{self.class.name} cannot be used on your" \

--- a/lib/tty/pager/version.rb
+++ b/lib/tty/pager/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module TTY
-  class Pager
-    VERSION = '0.12.1'
+  module Pager
+    VERSION = "0.12.1"
   end # Pager
 end # TTY

--- a/spec/unit/abstract_spec.rb
+++ b/spec/unit/abstract_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TTY::Pager::Abstract do
     allow(described_class).to receive(:new) { pager_instance }
 
     expect { |block|
-      described_class.page(command: "test", &block)
+      described_class.page(enabled: false, &block)
     }.to yield_with_args(pager_instance)
 
     expect(pager_instance).to have_received(:close)

--- a/spec/unit/abstract_spec.rb
+++ b/spec/unit/abstract_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Pager::Abstract do
+  it "configures instance to be enabled by default" do
+    pager = described_class.new
+
+    expect(pager.enabled?).to eq(true)
+  end
+
+  it "configures instance to be enabled" do
+    pager = described_class.new(enabled: false)
+
+    expect(pager.enabled?).to eq(false)
+  end
+
+  it "exposes class-level `page` implementation" do
+    pager_instance = spy(:pager)
+    allow(described_class).to receive(:new) { pager_instance }
+
+    expect { |block|
+      described_class.page(command: "test", &block)
+    }.to yield_with_args(pager_instance)
+
+    expect(pager_instance).to have_received(:close)
+  end
+
+  it "exposes instance-level `page` implementation" do
+    pager = described_class.new
+    allow(pager).to receive(:write)
+    allow(pager).to receive(:close)
+
+    pager.page("some text")
+
+    expect(pager).to have_received(:write).with("some text")
+    expect(pager).to have_received(:close)
+  end
+
+  it "requires `write` method implementation" do
+    pager = described_class.new
+
+    expect {
+      pager.write
+    }.to raise_error(TTY::Pager::Abstract::UndefinedMethodError)
+  end
+
+  it "requires `puts` method implementation" do
+    pager = described_class.new
+
+    expect {
+      pager.puts
+    }.to raise_error(TTY::Pager::Abstract::UndefinedMethodError)
+  end
+
+  it "requires `close` method implementation" do
+    pager = described_class.new
+
+    expect {
+      pager.close
+    }.to raise_error(TTY::Pager::Abstract::UndefinedMethodError)
+  end
+end


### PR DESCRIPTION
This extracts a common TTY::Pager::Abstract interface that requires overriding
write, puts and close methods. Changed Pager to be a module since it no longer
requires instantiation. Kept the #new method as a factory for the null, basic
and system pager instances. Made the #select_pager private to protect against
future changes. Only the top-level #page method remains as a convenience for
instance paging.

### Describe the change
Improves maintainability.

### Why are we doing this?
Better abstractions and maintenance

### Benefits
Clearer codebase.

### Drawbacks
Not that I can see.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[] Rebased with `master` branch?
[x] Documentation updated?
