### PR TITLE
Integration tests

### DIFF
--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -218,8 +218,9 @@ module TTY
           @io.close
           _, status = Process.waitpid2(@pid, Process::WNOHANG)
           status.success?
-        rescue Errno::ECHILD
-          # on jruby 9x waiting on pid raises
+        rescue Errno::ECHILD, Errno::EPIPE
+          # on jruby 9x waiting on pid raises ECHILD
+          # on ruby 2.5/2.6, closing a closed pipe raises EPIPE
           true
         end
 

--- a/spec/fixtures/cat.rb
+++ b/spec/fixtures/cat.rb
@@ -1,0 +1,1 @@
+STDOUT.write(ARGF.read)

--- a/spec/fixtures/external_pager.rb
+++ b/spec/fixtures/external_pager.rb
@@ -1,0 +1,6 @@
+ARGF.each do |line|
+  File.open('external_pager_output.txt', 'a') do |output|
+    output.puts(line)
+    output.flush
+  end
+end

--- a/spec/fixtures/external_pager.rb
+++ b/spec/fixtures/external_pager.rb
@@ -1,5 +1,7 @@
-ARGF.each do |line|
-  File.open('external_pager_output.txt', 'a') do |output|
+output_file = ARGV.first or raise "No output file given!"
+
+STDIN.each_line do |line|
+  File.open(output_file, 'a') do |output|
     output.puts(line)
     output.flush
   end

--- a/spec/integration/system_pager_spec.rb
+++ b/spec/integration/system_pager_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe TTY::Pager::SystemPager do
   around :each do |example|
-    mktmpdir do |dir|
+    Dir.mktmpdir do |dir|
       FileUtils.cd(dir) do
         example.run
       end

--- a/spec/integration/system_pager_spec.rb
+++ b/spec/integration/system_pager_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 RSpec.describe TTY::Pager::SystemPager do
   around :each do |example|
     Dir.mktmpdir do |dir|

--- a/spec/integration/system_pager_spec.rb
+++ b/spec/integration/system_pager_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe TTY::Pager::SystemPager do
       sleep 0.5
 
       pid = pager.instance_variable_get('@pager_io').instance_variable_get('@pid')
-      Process.kill('TERM', pid)
+      Process.kill('KILL', pid)
       Process.waitpid(pid)
 
       # Script finishes after two lines, this `puts` call should raise `PagerClosed`

--- a/spec/integration/system_pager_spec.rb
+++ b/spec/integration/system_pager_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Pager::SystemPager do
+  around :each do |example|
+    Dir.mktmpdir do |dir|
+      FileUtils.cd(dir) do
+        example.run
+      end
+    end
+  end
+
+  it "paginates some text" do
+    output_path = Pathname.new('output.txt')
+
+    described_class.page("Some text", command: "cat > #{output_path}")
+    expect(output_path.read).to eq "Some text"
+  end
+
+  it "allows pagination to happen asynchronously" do
+    output_path = Pathname.new('output.txt')
+    File.open('external_pager.rb', 'w') do |script|
+      script.write(<<~RUBY)
+        File.open('output.txt', 'w') do |output|
+          ARGF.each { |line| output.puts(line) }
+        end
+      RUBY
+    end
+
+    described_class.page(command: "ruby external_pager.rb") do |pager|
+      pager.puts("one")
+      pager.write("two\n")
+      pager.try_write("three\n")
+    end
+
+    expect(output_path.read).to eq "one\ntwo\nthree\n"
+  end
+
+  it "stops paginating once external tool is closed" do
+    output_path = Pathname.new('output.txt')
+    File.open('external_pager.rb', 'w') do |script|
+      script.write(<<~RUBY)
+        ARGF.each_with_index do |line, index|
+          File.open('output.txt', 'a') do |output|
+            output.puts(line)
+            output.flush
+          end
+        end
+      RUBY
+    end
+
+    described_class.page(command: "ruby external_pager.rb") do |pager|
+      pager.puts("one")
+      pager.puts("two")
+
+      # wait for script to finish writing
+      sleep 0.5
+
+      pid = pager.instance_variable_get('@pager_io').instance_variable_get('@pid')
+      Process.kill('TERM', pid)
+      Process.waitpid(pid)
+
+      # Script finishes after two lines, this `puts` call should raise `PagerClosed`
+      pager.puts("three")
+      raise "Should not be called"
+    end
+
+    expect(output_path.read).to eq "one\ntwo\n"
+  end
+end

--- a/spec/integration/system_pager_spec.rb
+++ b/spec/integration/system_pager_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe TTY::Pager::SystemPager do
   end
 
   it "allows pagination to happen asynchronously" do
-    output_path = Pathname.new('external_pager_output.txt')
-    described_class.page(command: "ruby #{fixtures_path('external_pager.rb')}") do |pager|
+    output_path = Pathname.new('output.txt')
+    pager_command = "ruby #{fixtures_path('external_pager.rb')} #{output_path}"
+
+    described_class.page(command: pager_command) do |pager|
       pager.puts("one")
       pager.write("two\n")
       pager.try_write("three\n")
@@ -28,8 +30,10 @@ RSpec.describe TTY::Pager::SystemPager do
   end
 
   it "stops paginating once external tool is closed" do
-    output_path = Pathname.new('external_pager_output.txt')
-    described_class.page(command: "ruby #{fixtures_path('external_pager.rb')}") do |pager|
+    output_path = Pathname.new('output.txt')
+    pager_command = "ruby #{fixtures_path('external_pager.rb')} #{output_path}"
+
+    described_class.page(command: pager_command) do |pager|
       pager.puts("one")
       pager.puts("two")
 

--- a/spec/integration/system_pager_spec.rb
+++ b/spec/integration/system_pager_spec.rb
@@ -11,22 +11,14 @@ RSpec.describe TTY::Pager::SystemPager do
 
   it "paginates some text" do
     output_path = Pathname.new('output.txt')
+    described_class.page("Some text", command: "ruby #{fixtures_path('cat.rb')} > #{output_path}")
 
-    described_class.page("Some text", command: "cat > #{output_path}")
     expect(output_path.read).to eq "Some text"
   end
 
   it "allows pagination to happen asynchronously" do
-    output_path = Pathname.new('output.txt')
-    File.open('external_pager.rb', 'w') do |script|
-      script.write(<<~RUBY)
-        File.open('output.txt', 'w') do |output|
-          ARGF.each { |line| output.puts(line) }
-        end
-      RUBY
-    end
-
-    described_class.page(command: "ruby external_pager.rb") do |pager|
+    output_path = Pathname.new('external_pager_output.txt')
+    described_class.page(command: "ruby #{fixtures_path('external_pager.rb')}") do |pager|
       pager.puts("one")
       pager.write("two\n")
       pager.try_write("three\n")
@@ -36,19 +28,8 @@ RSpec.describe TTY::Pager::SystemPager do
   end
 
   it "stops paginating once external tool is closed" do
-    output_path = Pathname.new('output.txt')
-    File.open('external_pager.rb', 'w') do |script|
-      script.write(<<~RUBY)
-        ARGF.each_with_index do |line, index|
-          File.open('output.txt', 'a') do |output|
-            output.puts(line)
-            output.flush
-          end
-        end
-      RUBY
-    end
-
-    described_class.page(command: "ruby external_pager.rb") do |pager|
+    output_path = Pathname.new('external_pager_output.txt')
+    described_class.page(command: "ruby #{fixtures_path('external_pager.rb')}") do |pager|
       pager.puts("one")
       pager.puts("two")
 

--- a/spec/integration/system_pager_spec.rb
+++ b/spec/integration/system_pager_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe TTY::Pager::SystemPager do
   around :each do |example|
-    Dir.mktmpdir do |dir|
+    mktmpdir do |dir|
       FileUtils.cd(dir) do
         example.run
       end

--- a/spec/integration/system_pager_spec.rb
+++ b/spec/integration/system_pager_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe TTY::Pager::SystemPager do
   end
 
   it "paginates some text" do
-    output_path = Pathname.new('output.txt')
-    described_class.page("Some text", command: "ruby #{fixtures_path('cat.rb')} > #{output_path}")
+    output_path = Pathname.new("output.txt")
+    described_class.page("Some text", command: "ruby #{fixtures_path("cat.rb")} > #{output_path}")
 
     expect(output_path.read).to eq "Some text"
   end
 
   it "allows pagination to happen asynchronously" do
-    output_path = Pathname.new('output.txt')
-    pager_command = "ruby #{fixtures_path('external_pager.rb')} #{output_path}"
+    output_path = Pathname.new("output.txt")
+    pager_command = "ruby #{fixtures_path("external_pager.rb")} #{output_path}"
 
     described_class.page(command: pager_command) do |pager|
       pager.puts("one")
@@ -30,8 +30,8 @@ RSpec.describe TTY::Pager::SystemPager do
   end
 
   it "stops paginating once external tool is closed" do
-    output_path = Pathname.new('output.txt')
-    pager_command = "ruby #{fixtures_path('external_pager.rb')} #{output_path}"
+    output_path = Pathname.new("output.txt")
+    pager_command = "ruby #{fixtures_path("external_pager.rb")} #{output_path}"
 
     described_class.page(command: pager_command) do |pager|
       pager.puts("one")
@@ -40,8 +40,8 @@ RSpec.describe TTY::Pager::SystemPager do
       # wait for script to finish writing
       sleep 0.5
 
-      pid = pager.instance_variable_get('@pager_io').instance_variable_get('@pid')
-      Process.kill('KILL', pid)
+      pid = pager.instance_variable_get("@pager_io").instance_variable_get("@pid")
+      Process.kill("KILL", pid)
       Process.waitpid(pid)
 
       # Script finishes after two lines, this `puts` call should raise `PagerClosed`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,14 +32,6 @@ module TestHelpers
     def fixtures_path(*args)
       ::File.expand_path(::File.join(dir_path("spec/fixtures"), *args))
     end
-
-    def mktmpdir
-      path = ::File.expand_path("#{Dir.tmpdir}/tty-pager-spec-#{Time.now.to_i}#{rand(1000)}/")
-      FileUtils.mkdir_p(path)
-      yield path
-    ensure
-      FileUtils.rm_rf(path) if File.exist?(path)
-    end
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,14 @@ module TestHelpers
     def fixtures_path(*args)
       ::File.expand_path(::File.join(dir_path("spec/fixtures"), *args))
     end
+
+    def mktmpdir
+      path = ::File.expand_path("#{Dir.tmpdir}/tty-pager-spec-#{Time.now.to_i}#{rand(1000)}/")
+      FileUtils.mkdir_p(path)
+      yield path
+    ensure
+      FileUtils.rm_rf(path) if File.exist?(path)
+    end
   end
 end
 


### PR DESCRIPTION
Reference: https://github.com/piotrmurach/tty-pager/issues/17

### Describe the change

This PR adds some experimental integration tests, particularly for the `SystemPager`. It could be argued that the `BasicPager`'s specs are already integration ones rather than unit ones, since they don't use stubs and actually write to some real IO.

### Why are we doing this / Benefits?

More confidence that the pager actually runs when a real process is spawned.

### Drawbacks

- There's a `sleep 0.5` in one of the tests that is there to ensure that writing to the file has finished. Otherwise the process gets killed too quickly. I haven't thought of how to avoid this and it could make the test fragile, and it definitely makes it slower than it needs to be.
- I don't know if the test will run successfully on Mac and on Windows.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[] Documentaion updated?
