### PR TITLE
Support absolute paths in the PAGER env var

### DIFF
--- a/lib/tty/pager/system.rb
+++ b/lib/tty/pager/system.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "open3"
+require 'pathname'
 
 require_relative "abstract"
 
@@ -23,10 +24,14 @@ module TTY
       #
       # @api private
       def self.command_exist?(command)
-        exts = ENV.fetch("PATHEXT", "").split(::File::PATH_SEPARATOR)
-        ENV.fetch("PATH", "").split(::File::PATH_SEPARATOR).any? do |dir|
-          file = ::File.join(dir, command)
-          ::File.exist?(file) || exts.any? { |ext| ::File.exist?("#{file}#{ext}") }
+        if Pathname.new(command).absolute?
+          File.exist?(command)
+        else
+          exts = ENV.fetch("PATHEXT", "").split(::File::PATH_SEPARATOR)
+          ENV.fetch("PATH", "").split(::File::PATH_SEPARATOR).any? do |dir|
+            file = ::File.join(dir, command)
+            ::File.exist?(file) || exts.any? { |ext| ::File.exist?("#{file}#{ext}") }
+          end
         end
       end
 

--- a/spec/unit/pager/system_spec.rb
+++ b/spec/unit/pager/system_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe TTY::Pager::SystemPager do
       expect(pager.command_exist?("less")).to eq(true)
     end
 
+    it "successfully checks command exists via an absolute path" do
+      allow(ENV).to receive(:fetch).with("PATHEXT", "").and_return("")
+      allow(ENV).to receive(:fetch).with("PATH", "").and_return("/usr/bin/")
+      allow(::File).to receive(:exist?)
+        .with("/other/path/to/less").and_return(true)
+
+      expect(pager.command_exist?("/other/path/to/less")).to eq(true)
+    end
+
     it "successfully checks command with extensions exists on the system" do
       allow(ENV).to receive(:fetch).with("PATHEXT", "").and_return(".exe")
       allow(ENV).to receive(:fetch).with("PATH", "").and_return("/usr/bin/")


### PR DESCRIPTION
Thanks @piotrmurach for working on this library, we use it in a range of our products. We noticed there is an inconsistency in how the `PAGER` environment variable handles absolute paths when compared to other linux utilities.

For example it is possible to tell `man` to use `more` (or vim less) as the pager by doing the following:
```
# Hard set more as the pager
export PAGER=$(which more)
man bash
... opens in more ...

# Use the less wrapper script that ships with vim
export PAGER=/usr/share/vim/vim82/macros/less.sh
man bash
... uses the vim version of less ...
```

The above does not work as expected with `TTY::PAGER` as the absolute paths are not on the `PATH`.

This PR updates the `command_exist?` method to first check if an absolute path has been provided before preforming the relative path lookup. This appears to be the most straight forward way to resolve the issue.